### PR TITLE
feat(evaluate): emit parse error on invalid JSONPointer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "apg-lite": "^1.0.4"
+        "apg-lite": "^1.0.5"
       },
       "devDependencies": {
         "@babel/cli": "=7.28.6",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "SECURITY.md"
   ],
   "dependencies": {
-    "apg-lite": "^1.0.4"
+    "apg-lite": "^1.0.5"
   },
   "devDependencies": {
     "@babel/cli": "=7.28.6",

--- a/test/evaluate/index.js
+++ b/test/evaluate/index.js
@@ -5,6 +5,7 @@ import {
   JSONPointerIndexError,
   JSONPointerTypeError,
   JSONPointerKeyError,
+  JSONPointerParseError,
   JSONPointerEvaluateError,
   URIFragmentIdentifier,
 } from '../../src/index.js';
@@ -85,8 +86,8 @@ describe('evaluate', function () {
   });
 
   context('invalid JSON Pointers (should throw errors)', function () {
-    specify('should throw JSONPointerEvaluateError for invalid JSON Pointer', function () {
-      assert.throws(() => evaluate(data, 'invalid-pointer'), JSONPointerEvaluateError);
+    specify('should throw JSONPointerParseError for invalid JSON Pointer', function () {
+      assert.throws(() => evaluate(data, 'invalid-pointer'), JSONPointerParseError);
     });
 
     specify(

--- a/test/evaluate/realms/apidom/evaluate.js
+++ b/test/evaluate/realms/apidom/evaluate.js
@@ -6,7 +6,7 @@ import {
   JSONPointerIndexError,
   JSONPointerTypeError,
   JSONPointerKeyError,
-  JSONPointerEvaluateError,
+  JSONPointerParseError,
   URIFragmentIdentifier,
 } from '../../../../src/index.js';
 import { evaluate } from '../../../../src/evaluate/realms/apidom/index.js';
@@ -91,8 +91,8 @@ describe('evaluate', function () {
     });
 
     context('invalid JSON Pointers (should throw errors)', function () {
-      specify('should throw JSONPointerEvaluateError for invalid JSON Pointer', function () {
-        assert.throws(() => evaluate(element, 'invalid-pointer'), JSONPointerEvaluateError);
+      specify('should throw JSONPointerParseError for invalid JSON Pointer', function () {
+        assert.throws(() => evaluate(element, 'invalid-pointer'), JSONPointerParseError);
       });
 
       specify(

--- a/test/evaluate/realms/apidom/index.js
+++ b/test/evaluate/realms/apidom/index.js
@@ -7,7 +7,7 @@ import {
   JSONPointerIndexError,
   JSONPointerTypeError,
   JSONPointerKeyError,
-  JSONPointerEvaluateError,
+  JSONPointerParseError,
   URIFragmentIdentifier,
 } from '../../../../src/index.js';
 import ApiDOMEvaluationRealm from '../../../../src/evaluate/realms/apidom/index.js';
@@ -101,10 +101,10 @@ describe('evaluate', function () {
     });
 
     context('invalid JSON Pointers (should throw errors)', function () {
-      specify('should throw JSONPointerEvaluateError for invalid JSON Pointer', function () {
+      specify('should throw JSONPointerParseError for invalid JSON Pointer', function () {
         assert.throws(
           () => evaluate(element, 'invalid-pointer', { realm }),
-          JSONPointerEvaluateError,
+          JSONPointerParseError,
         );
       });
 

--- a/test/evaluate/realms/immutable.js
+++ b/test/evaluate/realms/immutable.js
@@ -6,7 +6,7 @@ import {
   JSONPointerIndexError,
   JSONPointerTypeError,
   JSONPointerKeyError,
-  JSONPointerEvaluateError,
+  JSONPointerParseError,
   URIFragmentIdentifier,
 } from '../../../src/index.js';
 import ImmutableEvaluationRealm from '../../../src/evaluate/realms/immutable/index.js';
@@ -82,8 +82,8 @@ describe('evaluate', function () {
     });
 
     context('invalid JSON Pointers (should throw errors)', function () {
-      specify('should throw JSONPointerEvaluateError for invalid JSON Pointer', function () {
-        assert.throws(() => evaluate(map, 'invalid-pointer', { realm }), JSONPointerEvaluateError);
+      specify('should throw JSONPointerParseError for invalid JSON Pointer', function () {
+        assert.throws(() => evaluate(map, 'invalid-pointer', { realm }), JSONPointerParseError);
       });
 
       specify(

--- a/test/evaluate/realms/map-set.js
+++ b/test/evaluate/realms/map-set.js
@@ -5,7 +5,7 @@ import {
   JSONPointerIndexError,
   JSONPointerTypeError,
   JSONPointerKeyError,
-  JSONPointerEvaluateError,
+  JSONPointerParseError,
   URIFragmentIdentifier,
 } from '../../../src/index.js';
 import MapSetEvaluationRealm from '../../../src/evaluate/realms/map-set/index.js';
@@ -76,8 +76,8 @@ describe('evaluate', function () {
     });
 
     context('invalid JSON Pointers (should throw errors)', function () {
-      specify('should throw JSONPointerEvaluateError for invalid JSON Pointer', function () {
-        assert.throws(() => evaluate(data, 'invalid-pointer', { realm }), JSONPointerEvaluateError);
+      specify('should throw JSONPointerParseError for invalid JSON Pointer', function () {
+        assert.throws(() => evaluate(data, 'invalid-pointer', { realm }), JSONPointerParseError);
       });
 
       specify(

--- a/test/evaluate/realms/minim.js
+++ b/test/evaluate/realms/minim.js
@@ -6,7 +6,7 @@ import {
   JSONPointerIndexError,
   JSONPointerTypeError,
   JSONPointerKeyError,
-  JSONPointerEvaluateError,
+  JSONPointerParseError,
   URIFragmentIdentifier,
 } from '../../../src/index.js';
 import MinimEvaluationRealm from '../../../src/evaluate/realms/minim/index.js';
@@ -80,10 +80,10 @@ describe('evaluate', function () {
     });
 
     context('invalid JSON Pointers (should throw errors)', function () {
-      specify('should throw JSONPointerEvaluateError for invalid JSON Pointer', function () {
+      specify('should throw JSONPointerParseError for invalid JSON Pointer', function () {
         assert.throws(
           () => evaluate(element, 'invalid-pointer', { realm }),
-          JSONPointerEvaluateError,
+          JSONPointerParseError,
         );
       });
 

--- a/test/evaluate/trace.js
+++ b/test/evaluate/trace.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { evaluate, JSONPointerEvaluateError } from '../../src/index.js';
+import { evaluate, JSONPointerParseError } from '../../src/index.js';
 
 describe('evaluate', function () {
   context('given trace option as object', function () {
@@ -92,10 +92,11 @@ describe('evaluate', function () {
 
       assert.throws(
         () => evaluate({ a: { b: 'c' } }, '1', { trace }),
-        JSONPointerEvaluateError,
+        JSONPointerParseError,
         'Invalid JSON Pointer: "1". Syntax error at position 0, expected "/"',
       );
-      assert.lengthOf(trace.steps, 1);
+      // Parse errors occur before evaluation begins, so trace is not populated
+      assert.notProperty(trace, 'steps');
     });
   });
 
@@ -103,7 +104,7 @@ describe('evaluate', function () {
     specify('should produce error message with tracing info', function () {
       assert.throws(
         () => evaluate({ a: { b: 'c' } }, '1', { trace: true }),
-        JSONPointerEvaluateError,
+        JSONPointerParseError,
         'Invalid JSON Pointer: "1". Syntax error at position 0, expected "/"',
       );
     });
@@ -112,7 +113,7 @@ describe('evaluate', function () {
   specify('should produce error message without tracking info #1', function () {
     assert.throws(
       () => evaluate({ a: { b: 'c' } }, '1'),
-      JSONPointerEvaluateError,
+      JSONPointerParseError,
       'Invalid JSON Pointer: "1". Syntax error at position 0',
     );
   });
@@ -120,7 +121,7 @@ describe('evaluate', function () {
   specify('should produce error message without tracking info #2', function () {
     assert.throws(
       () => evaluate({ a: { b: 'c' } }, '1', { trace: false }),
-      JSONPointerEvaluateError,
+      JSONPointerParseError,
       'Invalid JSON Pointer: "1". Syntax error at position 0',
     );
   });


### PR DESCRIPTION
BREAKING CHANGE: evalute can now throw either JSONPointerParseError or busclasses of JSONPointerEvaluateError.